### PR TITLE
fix(callback_url): remove query_string

### DIFF
--- a/lib/omniauth/strategies/yandex.rb
+++ b/lib/omniauth/strategies/yandex.rb
@@ -34,7 +34,7 @@ module OmniAuth
         if options.authorize_options.respond_to? :callback_url
           options.authorize_options.callback_url
         else
-          super
+          "#{full_host}#{script_name}#{callback_path}"
         end
       end
 


### PR DESCRIPTION
Problem: 
Omniauth includes query string into callback url: https://github.com/omniauth/omniauth/blob/c2380ae848ce4e0e39b4bb94c5b8e3fd0a544825/lib/omniauth/strategy.rb#L443-L445
Yandex Oauth server requires any redirect_uri params to be included in its Callback URI. It prevents using any user-specific params(which our team need).
Solution: Do not include query string.
It seems to be a common approach:
for facebook: https://github.com/mkdynamic/omniauth-facebook/blob/a05db234f6f02a3c8cbae53eb6b5335d1a9dbfc6/lib/omniauth/strategies/facebook.rb#L83
for Vkontakte: https://github.com/mamantoha/omniauth-vkontakte/blob/33ee0a193a485cad63f9d9afece3bf86e134fbc3/lib/omniauth/strategies/vkontakte.rb#L99

internal ticket: https://jira.railsc.ru/browse/BPC-15445